### PR TITLE
Add Edge Scanner + Benchmark Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,13 @@ manual_parser = []
 print_parsed = []
 
 [[bench]]
-name = "parser_bench"
+name = "all"
+harness = false
+
+[[bench]]
+name = "arb"
+harness = false
+
+[[bench]]
+name = "parse"
 harness = false

--- a/README.md
+++ b/README.md
@@ -8,12 +8,10 @@ This project is designed to help answer questions like:
 * *How should we structure pricing paths to be both safe and efficient?*
 * *Which arb evaluation strategy scales best: precompiled loops, hash maps, deltas, or SIMD scans?*
 
-
 ## 🚧 Disclaimer
 
 **This project does *not* include trade execution, order placement, or connectivity to live accounts.**
 It is a research and development effort meant for educational purposes only. Do not use it for trading real funds.
-
 
 ## ✨ What We’ve Built So Far
 
@@ -36,11 +34,15 @@ It is a research and development effort meant for educational purposes only. Do 
 * Discovers all **valid 3-leg triangular paths** starting and ending in a "home" asset (e.g. USDT).
 * Each path is assigned a direction (`Bid` or `Ask`) based on trade flow.
 
-### ⚙️ Arb Evaluator (Precompiled)
+### 🧠 Arb Evaluators
 
-* **NaivePrecompiledScanner** tracks all configured triangles.
-* On each `TopOfBookUpdate`, recomputes the path profit in real-time.
-* Uses a shared `DashMap` store internally — others are free to use alternatives.
+Choose between multiple arbitrage evaluation strategies, each designed for different performance and complexity tradeoffs:
+
+* ✅ [`Naive Precompiled Scanner`](./src/arb/naive.rs)  
+* ✅ [`HashMap Edge Scanner`](./src/arb/edge.rs)  
+* 🛠️ [`Multithreaded Scan with Rayon`](./src/arb/rayon_scan.rs) *(planned)*
+* 🛠️ [`Delta-Based Scan`](./src/arb/delta.rs) *(planned)*  
+* 🛠️ [`SIMD Vectorized Evaluation`](./src/arb/simd.rs) *(planned)*  
 
 ### 🚀 Benchmarking
 

--- a/benches/all.rs
+++ b/benches/all.rs
@@ -1,0 +1,14 @@
+// benches/all.rs
+
+mod parse;
+mod arb;
+
+use criterion::criterion_main;
+
+use arb::arb_benches;
+use parse::parse_benches;
+
+criterion_main!(
+    arb_benches,
+    parse_benches,
+);

--- a/benches/arb.rs
+++ b/benches/arb.rs
@@ -1,0 +1,107 @@
+// benches/arb.rs
+
+use criterion::{criterion_group, Criterion, black_box, criterion_main};
+use tri_arb::arb::{ArbEvaluator, HashMapEdgeScanner, NaivePrecompiledScanner};
+use tri_arb::parse::TopOfBookUpdate;
+use tri_arb::price_path::{PricingPath, PathLeg, SymbolInfo, Side};
+
+
+fn sample_path() -> PricingPath {
+    let s1 = SymbolInfo {
+        symbol: "BTCUSDT".into(),
+        base_asset: "BTC".into(),
+        quote_asset: "USDT".into(),
+        status: "TRADING".into(),
+    };
+    let s2 = SymbolInfo {
+        symbol: "ETHBTC".into(),
+        base_asset: "ETH".into(),
+        quote_asset: "BTC".into(),
+        status: "TRADING".into(),
+    };
+    let s3 = SymbolInfo {
+        symbol: "ETHUSDT".into(),
+        base_asset: "ETH".into(),
+        quote_asset: "USDT".into(),
+        status: "TRADING".into(),
+    };
+    PricingPath {
+        leg1: PathLeg { symbol: s1, side: Side::Ask },
+        leg2: PathLeg { symbol: s2, side: Side::Ask },
+        leg3: PathLeg { symbol: s3, side: Side::Bid },
+    }
+}
+
+
+fn mock_updates(count: usize) -> Vec<TopOfBookUpdate> {
+    let mut updates = Vec::with_capacity(count);
+    for i in 0..count {
+        let symbol = match i % 3 {
+            0 => "BTCUSDT",
+            1 => "ETHBTC",
+            _ => "ETHUSDT",
+        };
+        updates.push(TopOfBookUpdate {
+            symbol: symbol.to_string(),
+            bid_price: 1.0 + (i as f64 % 100.0) * 0.0001,
+            ask_price: 1.0 + (i as f64 % 100.0) * 0.00015,
+        });
+    }
+    updates
+}
+
+pub fn bench_evaluators(c: &mut Criterion) {
+    let updates = mock_updates(10);
+    let paths = vec![sample_path()]; // 10 copies
+
+    let naive = NaivePrecompiledScanner::new(paths.clone());
+    let edge = HashMapEdgeScanner::new(paths.clone());
+
+    c.bench_function("arb/naive/process_update", |b| {
+        b.iter(|| {
+            for u in black_box(&updates) {
+                let _ = naive.process_update(u);
+            }
+        })
+    });
+
+    c.bench_function("arb/edge/process_update", |b| {
+        b.iter(|| {
+            for u in black_box(&updates) {
+                let _ = edge.process_update(u);
+            }
+        })
+    }); 
+}
+
+fn bench_overload_scanners(c: &mut Criterion) {
+    
+    let updates = mock_updates(500_000);
+    let paths = vec![sample_path()];
+    let naive = NaivePrecompiledScanner::new(paths.clone());
+    let edge = HashMapEdgeScanner::new(paths.clone());
+
+    c.bench_function("arb/naive/heavy_update", |b| {
+        b.iter(|| {
+            for u in black_box(&updates) {
+                let _ = naive.process_update(u);
+            }
+        })
+    });
+
+    c.bench_function("arb/edge/heavy_update", |b| {
+        b.iter(|| {
+            for u in black_box(&updates) {
+                let _ = edge.process_update(u);
+            }
+        })
+    });
+}
+
+criterion_group!(
+    arb_benches,
+    bench_evaluators,
+    bench_overload_scanners
+);
+
+criterion_main!(arb_benches);

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,31 +1,31 @@
-// benches/parser_bench.rs
+// benches/parse.rs
 
-use criterion::{criterion_group, criterion_main, Criterion, black_box};
+use criterion::{criterion_group, Criterion, black_box, criterion_main};
 use bytes::Bytes;
 use tri_arb::parse::{srd_jsn::SerdeJsonParser, man_scan::ManualScanParser, BookTickerParser};
 
 const SAMPLE_MSG: &str = r#"{"e":"bookTicker","u":123456,"s":"BTCUSDT","b":"30000.12","B":"1.0","a":"30001.45","A":"2.0"}"#;
 
-pub fn benchmark_single_parse(c: &mut Criterion) {
+pub fn bench_single_parse(c: &mut Criterion) {
     let input = Bytes::from_static(SAMPLE_MSG.as_bytes());
 
     let serde_parser = SerdeJsonParser;
     let manual_parser = ManualScanParser;
 
-    c.bench_function("single_parse_serde_json", |b| {
+    c.bench_function("parse/serde_json/single", |b| {
         b.iter(|| {
             let _ = serde_parser.parse(black_box(&input)).unwrap();
         })
     });
 
-    c.bench_function("single_parse_manual_scan", |b| {
+    c.bench_function("parse/manual_scan/single", |b| {
         b.iter(|| {
             let _ = manual_parser.parse(black_box(&input)).unwrap();
         })
     });
 }
 
-pub fn benchmark_batch_parse(c: &mut Criterion) {
+pub fn bench_batch_parse(c: &mut Criterion) {
     let single_msg = Bytes::from_static(SAMPLE_MSG.as_bytes());
     let batch_size = 100_000; // TODO parametrize it with ParameterizedBenchmark (advanced Criterion usage)
 
@@ -37,7 +37,7 @@ pub fn benchmark_batch_parse(c: &mut Criterion) {
     let serde_parser = SerdeJsonParser;
     let manual_parser = ManualScanParser;
 
-    c.bench_function(&format!("batch_parse_serde_json_batch_{}", batch_size), |b| {
+    c.bench_function(&format!("parse/serde_json/batch_parse_{}", batch_size), |b| {
         b.iter(|| {
             for msg in black_box(&batch) {
                 let _ = serde_parser.parse(msg).unwrap();
@@ -45,7 +45,7 @@ pub fn benchmark_batch_parse(c: &mut Criterion) {
         })
     });
 
-    c.bench_function(&format!("batch_parse_manual_scan_batch_{}", batch_size), |b| {
+    c.bench_function(&format!("parse/manual_scan/batch_parse_{}", batch_size), |b| {
         b.iter(|| {
             for msg in black_box(&batch) {
                 let _ = manual_parser.parse(msg).unwrap();
@@ -55,8 +55,11 @@ pub fn benchmark_batch_parse(c: &mut Criterion) {
 }
 
 criterion_group!(
-    benches,
-    benchmark_single_parse,
-    benchmark_batch_parse
+    parse_benches,
+    bench_single_parse,
+    bench_batch_parse,
 );
-criterion_main!(benches);
+
+criterion_main!(
+    parse_benches
+);

--- a/src/arb/edge.rs
+++ b/src/arb/edge.rs
@@ -1,0 +1,126 @@
+// src/arb/edge.rs
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+
+use crate::arb::ArbEvaluator;
+use crate::parse::TopOfBookUpdate;
+use crate::price_path::{PricingPath, Side};
+
+/// A fast arbitrage evaluator that indexes triangular paths by symbol (edge)
+/// so only relevant paths are re-evaluated on each update.
+pub struct HashMapEdgeScanner {
+    price_store: DashMap<String, TopOfBookUpdate>,
+    path_index: HashMap<String, Vec<Arc<PricingPath>>>
+}
+
+impl HashMapEdgeScanner {
+    /// Constructs a new HashMapEdgeScanner by indexing all paths by the symbols they reference.
+    pub fn new(price_paths: Vec<PricingPath>) -> Self {
+        let wrapped_paths: Vec<Arc<PricingPath>> = price_paths.into_iter().map(Arc::new).collect();
+        let mut index: HashMap<String, Vec<Arc<PricingPath>>> = HashMap::with_capacity(wrapped_paths.len() * 3);
+
+        for path in &wrapped_paths {
+            for symbol in path.symbols() {
+                index.entry(symbol).or_default().push(Arc::clone(path));
+            }
+        }
+        
+        Self {
+            price_store: DashMap::new(),
+            path_index: index,    
+        }
+    }
+}
+
+impl ArbEvaluator for HashMapEdgeScanner {
+    /// Processes a top-of-book update and checks for arbitrage opportunities
+    /// using only paths involving the updated symbol.
+    fn process_update(&self, update: &TopOfBookUpdate) -> Option<(PricingPath, f64)> {
+        self.price_store.insert(update.symbol.clone(), update.clone());
+
+        if let Some(paths) = self.path_index.get(&update.symbol) {
+            for path in paths {
+                let Some(p1) = self.price_store.get(&path.leg1.symbol.symbol) else { continue; };
+                let Some(p2) = self.price_store.get(&path.leg2.symbol.symbol) else { continue; };
+                let Some(p3) = self.price_store.get(&path.leg3.symbol.symbol) else { continue; };
+                
+                const START: f64 = 1.0;
+
+                let step1 = match path.leg1.side {
+                    Side::Ask => START / p1.ask_price,
+                    Side::Bid => START * p1.bid_price,
+                };
+
+                let step2 = match path.leg2.side {
+                    Side::Ask => step1 /  p2.ask_price,
+                    Side::Bid => step1 * p2.bid_price 
+                };
+
+                let end = match path.leg3.side {
+                    Side::Ask => step2 / p3.ask_price,
+                    Side::Bid => step2 * p3.bid_price,
+                };
+
+                if end > START {
+                    return Some((path.as_ref().clone(), end));
+                };
+            }
+        }
+        None
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::price_path::{PathLeg, SymbolInfo};
+
+    fn mock_path() -> PricingPath {
+        let s1 = SymbolInfo {
+            symbol: "BTCUSDT".into(),
+            base_asset: "BTC".into(),
+            quote_asset: "USDT".into(),
+            status: "TRADING".into(),
+        };
+        let s2 = SymbolInfo {
+            symbol: "ETHBTC".into(),
+            base_asset: "ETH".into(),
+            quote_asset: "BTC".into(),
+            status: "TRADING".into(),
+        };
+        let s3 = SymbolInfo {
+            symbol: "ETHUSDT".into(),
+            base_asset: "ETH".into(),
+            quote_asset: "USDT".into(),
+            status: "TRADING".into(),
+        };
+
+        PricingPath {
+            leg1: PathLeg { symbol: s1, side: Side::Ask },
+            leg2: PathLeg { symbol: s2, side: Side::Ask },
+            leg3: PathLeg { symbol: s3, side: Side::Bid },
+        }
+    }
+
+    #[test]
+    fn test_indexing_symbols_from_paths() {
+        let path = mock_path();
+        let scanner = HashMapEdgeScanner::new(vec![path]);
+
+        assert!(scanner.path_index.contains_key("BTCUSDT"));
+        assert!(scanner.path_index.contains_key("ETHBTC"));
+        assert!(scanner.path_index.contains_key("ETHUSDT"));
+    }
+
+    #[test]
+    fn test_no_false_positive_paths() {
+        let path = mock_path();
+        let scanner = HashMapEdgeScanner::new(vec![path]);
+
+        assert!(!scanner.path_index.contains_key("FOOBAR"));
+    }
+}

--- a/src/arb/mod.rs
+++ b/src/arb/mod.rs
@@ -4,13 +4,31 @@ use std::sync::Arc;
 use anyhow::Result;
 use tokio::sync::mpsc::Receiver;
 
-use crate::parse::TopOfBookUpdate;
+use crate::{parse::TopOfBookUpdate, price_path::PricingPath};
 
 pub mod naive;
-pub use naive::Triangle;
+pub mod edge;
+pub use naive::NaivePrecompiledScanner;
+pub use edge::HashMapEdgeScanner;
+
+#[derive(Debug, Clone, Copy)]
+pub enum ArbMode {
+    Naive,
+    EdgeMap
+}
+
+pub fn create_arb_evaluator(
+    mode: ArbMode,
+    price_paths: Vec<PricingPath>
+) -> Arc<dyn ArbEvaluator + Send + Sync> {
+    match mode {
+        ArbMode::Naive => Arc::new(NaivePrecompiledScanner::new(price_paths)),
+        ArbMode::EdgeMap => Arc::new(HashMapEdgeScanner::new(price_paths)),
+    }
+}
 
 pub trait ArbEvaluator: Send + Sync {
-    fn process_update(&self, update: &TopOfBookUpdate);
+    fn process_update(&self, update: &TopOfBookUpdate) -> Option<(PricingPath, f64)>;
 }
 
 pub async fn arb_loop(
@@ -18,7 +36,68 @@ pub async fn arb_loop(
     evaluator: Arc<dyn ArbEvaluator>,
 ) -> Result<()> {
     while let Some(update) = rx.recv().await {
-        evaluator.process_update(&update);
+        if let Some((path, result)) = evaluator.process_update(&update) {
+            println!(
+                "✅ Arbitrage found: {} | Return: {:.6} | Profit: {:.4}%",
+                path,
+                result,
+                (result - 1.0) * 100.0
+            );
+        }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::price_path::{PathLeg, PricingPath, Side, SymbolInfo};
+
+    fn mock_path() -> PricingPath {
+        let s1 = SymbolInfo {
+            symbol: "BTCUSDT".into(),
+            base_asset: "BTC".into(),
+            quote_asset: "USDT".into(),
+            status: "TRADING".into(),
+        };
+        let s2 = SymbolInfo {
+            symbol: "ETHBTC".into(),
+            base_asset: "ETH".into(),
+            quote_asset: "BTC".into(),
+            status: "TRADING".into(),
+        };
+        let s3 = SymbolInfo {
+            symbol: "ETHUSDT".into(),
+            base_asset: "ETH".into(),
+            quote_asset: "USDT".into(),
+            status: "TRADING".into(),
+        };
+
+        PricingPath {
+            leg1: PathLeg { symbol: s1, side: Side::Ask },
+            leg2: PathLeg { symbol: s2, side: Side::Ask },
+            leg3: PathLeg { symbol: s3, side: Side::Bid },
+        }
+    }
+
+    fn mock_update(symbol: &str, bid: f64, ask: f64) -> TopOfBookUpdate {
+        TopOfBookUpdate {
+            symbol: symbol.to_string(),
+            bid_price: bid,
+            ask_price: ask,
+        }
+    }
+
+    #[test]
+    fn test_edge_scanner_accepts_update() {
+        let path = mock_path();
+        let scanner = HashMapEdgeScanner::new(vec![path]);
+
+        scanner.process_update(&mock_update("BTCUSDT", 30000.0, 30010.0));
+        scanner.process_update(&mock_update("ETHBTC", 0.065, 0.066));
+        scanner.process_update(&mock_update("ETHUSDT", 1980.0, 1985.0));
+
+        // There's no assertion here yet, since current logic just prints.
+        // You can add a counter, hook, or event log in future versions to validate detection.
+    }
 }

--- a/src/arb/naive.rs
+++ b/src/arb/naive.rs
@@ -7,20 +7,13 @@ use crate::price_path::{PricingPath, Side};
 
 use super::ArbEvaluator;
 
-#[derive(Debug, Clone)]
-pub struct Triangle {
-    pub leg1: String,
-    pub leg2: String,
-    pub leg3: String,
-}
-
 pub struct NaivePrecompiledScanner {
     paths: Vec<PricingPath>,
     price_store: DashMap<String, TopOfBookUpdate>,
 }
 
 impl ArbEvaluator for NaivePrecompiledScanner {
-    fn process_update(&self, update: &TopOfBookUpdate) {
+    fn process_update(&self, update: &TopOfBookUpdate) -> Option<(PricingPath, f64)> {
         self.price_store.insert(update.symbol.clone(), update.clone());
 
         for path in self.paths.iter() {
@@ -28,11 +21,11 @@ impl ArbEvaluator for NaivePrecompiledScanner {
             let Some(p2) = self.price_store.get(&path.leg2.symbol.symbol) else { continue; };
             let Some(p3) = self.price_store.get(&path.leg3.symbol.symbol) else { continue; };
             
-            let start = 1.0;
+            const START: f64 = 1.0;
             
             let step1 = match path.leg1.side {
-                Side::Ask => start / p1.ask_price,
-                Side::Bid => start * p1.bid_price,
+                Side::Ask => START / p1.ask_price,
+                Side::Bid => START * p1.bid_price,
             };
 
             let step2 = match path.leg2.side {
@@ -40,20 +33,16 @@ impl ArbEvaluator for NaivePrecompiledScanner {
                 Side::Bid => step1 * p2.bid_price,
             };
 
-            let final_amount = match path.leg3.side {
+            let end = match path.leg3.side {
                 Side::Ask => step2 / p3.ask_price,
                 Side::Bid => step2 * p3.bid_price
             };
 
-            if final_amount > start {
-                println!(
-                    "✅ Arbitrage! {} | Start: {:.6} End: {:.6} Profit: {:.6}",
-                    path,
-                    start, final_amount,
-                    final_amount - start
-                );
-            }
+            if end > START {
+                return Some((path.clone(), end));
+            };
         }
+        None
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,39 @@
 // src/main.rs
 
-use std::sync::Arc;
 use bytes::Bytes;
 use anyhow::Result;
 use tri_arb::parse::{parser_loop, TopOfBookUpdate};
 use tri_arb::ws::start_ws_listener;
-use tri_arb::arb::{naive::NaivePrecompiledScanner, arb_loop};
+use tri_arb::arb::{create_arb_evaluator, arb_loop, ArbMode};
 use tri_arb::price_path::find_and_build_price_paths;
 use tokio::sync::mpsc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    println!("Starting Binance WS listener");
+    
+    println!("Starting TriArb");
+    
+    // Config inputs
     let home_asset = "USDT";
     let targets = ["BTC", "ETH", "SOL"];
+    let arb_eval_mode = ArbMode::EdgeMap;
+    println!("Home asset: {}", home_asset);
+    println!("Target assets: {:?}", targets);
+    println!("Running with arbitrage evaluator mode: {:?}", arb_eval_mode);
     
+    // Create resources
     let price_paths = find_and_build_price_paths(home_asset, &targets)?;
-    
-    let evaluator = Arc::new(NaivePrecompiledScanner::new(price_paths.clone()));
-    
+    let evaluator = create_arb_evaluator(arb_eval_mode, price_paths.clone());
     let (ws_tx, ws_rx) = mpsc::channel::<Bytes>(4096);
     let (parser_tx, parser_rx) = mpsc::channel::<TopOfBookUpdate>(4096);
     
+    // Start loops
     tokio::spawn(arb_loop(parser_rx, evaluator));
     tokio::spawn(parser_loop(ws_rx, parser_tx));
     tokio::spawn(start_ws_listener(price_paths.clone(), ws_tx));
     
     tokio::signal::ctrl_c().await?;
     println!("Shutdown signal received");
+    
     Ok(())
 }


### PR DESCRIPTION
This PR introduces the `HashMapEdgeScanner` arbitrage evaluator and restructures the benchmark system to support evaluator comparisons.

---

## ✨ What's New

### 🔁 `HashMapEdgeScanner`

A new arbitrage evaluation strategy that:

* Indexes all pricing paths by their edge (symbol) for fast lookup.
* On each top-of-book update, only evaluates paths that include the updated symbol.
* Significantly reduces redundant computation compared to the naive strategy.
* Returns `(PricingPath, f64)` on arb opportunities for future trade execution hooks.

### 🧠 Trait Update: `ArbEvaluator`

* `process_update` now returns `Option<(PricingPath, f64)>` instead of `void`.
* Enables future extensions like CLI reporting, logging, or order execution.
* Moved `println!()` out of evaluator logic and into the `arb_loop`.

### 📊 Benchmark Suite Restructure

* New `benches/arb/mod.rs` module for evaluator benchmarking.
* `criterion_main!` now supports running parse and arb benchmarks independently or together.
* Laid foundation for future stress tests and load-based performance comparison.

---

## ✅ Why It Matters

* Paves the way for production-ready arb evaluation logic.
* Decouples core scanning from reporting and logging.
* Modular, scalable, and benchmark-driven foundation for exploring future strategies (delta-based, SIMD, etc).
